### PR TITLE
refactor: deepen auth workflow examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ node_modules
 
 # Testing
 coverage
+playwright-report
+test-results
 
 # Turbo
 .turbo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,5 @@ Default vocabulary (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-
 Multi-context monorepo — `CONTEXT-MAP.md` at root points to per-app `CONTEXT.md` files. See `docs/agents/domain.md`.
 
 ## Surprises / Confusion Points
+
+- `apps/react-router-web` reads the repo root `.env` by default via `apps/react-router-web/index.js`, and that file may point at a remote Supabase instance. Local e2e work that is meant to run against `supabase start` must override the app's Supabase env explicitly instead of trusting the default `.env`.

--- a/apps/react-router-web/CONTEXT.md
+++ b/apps/react-router-web/CONTEXT.md
@@ -49,6 +49,15 @@ Data is fetched server-side via React Router loaders:
 
 Loaders run on the server, so they have access to cookies and server-side Supabase client.
 
+### Auth workflow module
+
+Auth mutations use route actions as thin framework adapters around `app/auth/workflows/`:
+- `server.ts` — creates the Supabase adapter and preserves response headers
+- `operations.ts` — owns validation, auth orchestration, and result shaping
+- `types.ts` / `validation.ts` — define the auth workflow interface and invariants
+
+Routes such as `login.tsx`, `sign-up.tsx`, `forgot-password.tsx`, `update-password.tsx`, and `logout.tsx` translate `FormData` and redirects around the auth workflow module instead of owning the auth rules directly.
+
 ### Supabase integration
 
 Two clients in `app/lib/supabase/`:
@@ -99,3 +108,5 @@ Express adapter includes:
 | **Loader** | A React Router function that fetches data server-side before rendering a route |
 | **Nonce** | A per-request cryptographic token injected into CSP headers to allow specific inline scripts |
 | **Action route** | A file prefixed with `action.` that handles form submissions and mutations |
+| **Auth workflow** | The local module in `app/auth/workflows/` that owns auth validation, Supabase orchestration, and typed auth results |
+| **Framework adapter** | A route action or form that translates React Router request/response details around the auth workflow |

--- a/apps/react-router-web/app/auth/workflows/operations.test.ts
+++ b/apps/react-router-web/app/auth/workflows/operations.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  login,
+  logout,
+  signUp,
+  startOAuthLogin,
+  startPasswordReset,
+  updatePassword,
+} from "./operations";
+import type { AuthAdapter } from "./types";
+
+const config = {
+  protectedRedirect: "/protected",
+  signUpRedirect: "/sign-up?success",
+  forgotPasswordRedirect: "/forgot-password?success",
+  loginRedirect: "/protected",
+  logoutRedirect: "/",
+};
+
+function createAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+  return {
+    signInWithPassword: vi.fn(async () => ({ error: null })),
+    signUp: vi.fn(async () => ({ error: null })),
+    resetPasswordForEmail: vi.fn(async () => ({ error: null })),
+    updatePassword: vi.fn(async () => ({ error: null })),
+    signOut: vi.fn(async () => ({ error: null })),
+    signInWithOAuth: vi.fn(async () => ({
+      error: null,
+      url: "https://example.com/oauth",
+    })),
+    ...overrides,
+  };
+}
+
+describe("react-router auth workflow operations", () => {
+  it("rejects empty login input before the adapter", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await login({ email: "", password: "" }, auth, config);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Email is required",
+      fieldErrors: { email: "Required" },
+    });
+    expect(auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("returns the route redirect for successful login", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await login(
+      { email: "m@example.com", password: "secret" },
+      auth,
+      config,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "signed-in",
+      redirectTo: "/protected",
+    });
+  });
+
+  it("keeps sign-up password matching inside the workflow", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await signUp(
+      {
+        email: "m@example.com",
+        password: "secret",
+        repeatPassword: "different",
+        emailRedirectTo: "http://localhost:3000/protected",
+      },
+      auth,
+      config,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Passwords do not match",
+      fieldErrors: {
+        repeatPassword: "Must match password",
+      },
+    });
+  });
+
+  it("returns the success redirect for forgot-password", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await startPasswordReset(
+      {
+        email: "m@example.com",
+        redirectTo: "http://localhost:3000/auth/confirm?next=/update-password",
+      },
+      auth,
+      config,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "password-reset-requested",
+      redirectTo: "/forgot-password?success",
+      message: "Password reset instructions sent",
+    });
+  });
+
+  it("returns the protected redirect after password update", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await updatePassword({ password: "new-secret" }, auth, config);
+
+    expect(result).toEqual({
+      ok: true,
+      status: "password-updated",
+      redirectTo: "/protected",
+    });
+  });
+
+  it("returns an oauth redirect URL", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await startOAuthLogin(
+      { origin: "http://localhost:3000" },
+      auth,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "oauth-redirect",
+      externalUrl: "https://example.com/oauth",
+    });
+  });
+
+  it("returns the logout redirect from the workflow", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await logout(auth, config);
+
+    expect(result).toEqual({
+      ok: true,
+      status: "signed-out",
+      redirectTo: "/",
+    });
+  });
+});

--- a/apps/react-router-web/app/auth/workflows/operations.ts
+++ b/apps/react-router-web/app/auth/workflows/operations.ts
@@ -1,0 +1,129 @@
+import type {
+  AuthAdapter,
+  AuthWorkflowResult,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+import {
+  validateLoginInput,
+  validateOAuthLoginInput,
+  validatePasswordResetInput,
+  validateSignUpInput,
+  validateUpdatePasswordInput,
+} from "./validation";
+
+type AuthWorkflowConfig = {
+  protectedRedirect: string;
+  signUpRedirect: string;
+  forgotPasswordRedirect: string;
+  loginRedirect: string;
+  logoutRedirect: string;
+};
+
+export async function login(
+  input: LoginInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateLoginInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.signInWithPassword(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-in",
+    redirectTo: config.loginRedirect,
+  };
+}
+
+export async function signUp(
+  input: SignUpInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateSignUpInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.signUp(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-up",
+    redirectTo: config.signUpRedirect,
+  };
+}
+
+export async function startPasswordReset(
+  input: StartPasswordResetInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validatePasswordResetInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.resetPasswordForEmail(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "password-reset-requested",
+    redirectTo: config.forgotPasswordRedirect,
+    message: "Password reset instructions sent",
+  };
+}
+
+export async function updatePassword(
+  input: UpdatePasswordInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateUpdatePasswordInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.updatePassword(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "password-updated",
+    redirectTo: config.protectedRedirect,
+  };
+}
+
+export async function logout(
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const { error } = await auth.signOut();
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-out",
+    redirectTo: config.logoutRedirect,
+  };
+}
+
+export async function startOAuthLogin(
+  input: StartOAuthLoginInput,
+  auth: AuthAdapter,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateOAuthLoginInput(input);
+  if (invalid) return invalid;
+
+  const { error, url } = await auth.signInWithOAuth(input);
+  if (error) return { ok: false, message: error };
+  if (!url) return { ok: false, message: "Missing OAuth redirect URL" };
+
+  return {
+    ok: true,
+    status: "oauth-redirect",
+    externalUrl: url,
+  };
+}

--- a/apps/react-router-web/app/auth/workflows/server.ts
+++ b/apps/react-router-web/app/auth/workflows/server.ts
@@ -1,0 +1,109 @@
+import { createClient } from "~/lib/supabase/server";
+import type {
+  AuthAdapter,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+import {
+  login as loginOperation,
+  logout as logoutOperation,
+  signUp as signUpOperation,
+  startOAuthLogin as startOAuthLoginOperation,
+  startPasswordReset as startPasswordResetOperation,
+  updatePassword as updatePasswordOperation,
+} from "./operations";
+
+const config = {
+  protectedRedirect: "/protected",
+  signUpRedirect: "/sign-up?success",
+  forgotPasswordRedirect: "/forgot-password?success",
+  loginRedirect: "/protected",
+  logoutRedirect: "/",
+};
+
+function createAuthAdapter(request: Request) {
+  const { supabase, headers } = createClient(request);
+
+  const auth: AuthAdapter = {
+    async signInWithPassword(input) {
+      const { error } = await supabase.auth.signInWithPassword(input);
+      return { error: error?.message ?? null };
+    },
+    async signUp(input) {
+      const { error } = await supabase.auth.signUp({
+        email: input.email,
+        password: input.password,
+        options: {
+          emailRedirectTo: input.emailRedirectTo,
+        },
+      });
+      return { error: error?.message ?? null };
+    },
+    async resetPasswordForEmail(input) {
+      const { error } = await supabase.auth.resetPasswordForEmail(input.email, {
+        redirectTo: input.redirectTo,
+      });
+      return { error: error?.message ?? null };
+    },
+    async updatePassword(input) {
+      const { error } = await supabase.auth.updateUser({
+        password: input.password,
+      });
+      return { error: error?.message ?? null };
+    },
+    async signOut() {
+      const { error } = await supabase.auth.signOut();
+      return { error: error?.message ?? null };
+    },
+    async signInWithOAuth(input) {
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: `${input.origin}/auth/oauth?next=/protected`,
+        },
+      });
+      return { error: error?.message ?? null, url: data.url ?? null };
+    },
+  };
+
+  return { auth, headers };
+}
+
+export async function login(request: Request, input: LoginInput) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await loginOperation(input, auth, config), headers };
+}
+
+export async function signUp(request: Request, input: SignUpInput) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await signUpOperation(input, auth, config), headers };
+}
+
+export async function startPasswordReset(
+  request: Request,
+  input: StartPasswordResetInput,
+) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await startPasswordResetOperation(input, auth, config), headers };
+}
+
+export async function updatePassword(request: Request, input: UpdatePasswordInput) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await updatePasswordOperation(input, auth, config), headers };
+}
+
+export async function logout(request: Request) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await logoutOperation(auth, config), headers };
+}
+
+export async function startOAuthLogin(
+  request: Request,
+  input: StartOAuthLoginInput,
+) {
+  const { auth, headers } = createAuthAdapter(request);
+  return { result: await startOAuthLoginOperation(input, auth), headers };
+}

--- a/apps/react-router-web/app/auth/workflows/server.ts
+++ b/apps/react-router-web/app/auth/workflows/server.ts
@@ -17,10 +17,10 @@ import {
 } from "./operations";
 
 const config = {
-  protectedRedirect: "/protected",
+  protectedRedirect: "/test",
   signUpRedirect: "/sign-up?success",
   forgotPasswordRedirect: "/forgot-password?success",
-  loginRedirect: "/protected",
+  loginRedirect: "/test",
   logoutRedirect: "/",
 };
 

--- a/apps/react-router-web/app/auth/workflows/types.ts
+++ b/apps/react-router-web/app/auth/workflows/types.ts
@@ -1,0 +1,74 @@
+export type AuthFieldErrors = Partial<
+  Record<"email" | "password" | "repeatPassword" | "origin", string>
+>;
+
+export type AuthWorkflowFailure = {
+  ok: false;
+  message: string;
+  fieldErrors?: AuthFieldErrors;
+};
+
+export type AuthWorkflowSuccess =
+  | {
+      ok: true;
+      status: "signed-in" | "signed-up" | "password-updated" | "signed-out";
+      redirectTo: string;
+    }
+  | {
+      ok: true;
+      status: "password-reset-requested";
+      redirectTo: string;
+      message: string;
+    }
+  | {
+      ok: true;
+      status: "oauth-redirect";
+      externalUrl: string;
+    };
+
+export type AuthWorkflowResult = AuthWorkflowFailure | AuthWorkflowSuccess;
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type SignUpInput = {
+  email: string;
+  password: string;
+  repeatPassword: string;
+  emailRedirectTo: string;
+};
+
+export type StartPasswordResetInput = {
+  email: string;
+  redirectTo: string;
+};
+
+export type UpdatePasswordInput = {
+  password: string;
+};
+
+export type StartOAuthLoginInput = {
+  origin: string;
+};
+
+export type AuthAdapter = {
+  signInWithPassword(input: { email: string; password: string }): Promise<{
+    error: string | null;
+  }>;
+  signUp(input: {
+    email: string;
+    password: string;
+    emailRedirectTo: string;
+  }): Promise<{ error: string | null }>;
+  resetPasswordForEmail(input: {
+    email: string;
+    redirectTo: string;
+  }): Promise<{ error: string | null }>;
+  updatePassword(input: { password: string }): Promise<{ error: string | null }>;
+  signOut(): Promise<{ error: string | null }>;
+  signInWithOAuth(input: {
+    origin: string;
+  }): Promise<{ error: string | null; url: string | null }>;
+};

--- a/apps/react-router-web/app/auth/workflows/validation.ts
+++ b/apps/react-router-web/app/auth/workflows/validation.ts
@@ -1,0 +1,62 @@
+import type {
+  AuthWorkflowFailure,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+
+function failure(
+  message: string,
+  fieldErrors?: AuthWorkflowFailure["fieldErrors"],
+): AuthWorkflowFailure {
+  return { ok: false, message, fieldErrors };
+}
+
+export function validateLoginInput(input: LoginInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  return null;
+}
+
+export function validateSignUpInput(input: SignUpInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  if (!input.repeatPassword) {
+    return failure("Repeat password is required", {
+      repeatPassword: "Required",
+    });
+  }
+  if (input.password !== input.repeatPassword) {
+    return failure("Passwords do not match", {
+      repeatPassword: "Must match password",
+    });
+  }
+  if (!input.emailRedirectTo) {
+    return failure("Missing sign-up redirect target");
+  }
+  return null;
+}
+
+export function validatePasswordResetInput(input: StartPasswordResetInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.redirectTo) return failure("Missing password reset redirect target");
+  return null;
+}
+
+export function validateUpdatePasswordInput(input: UpdatePasswordInput) {
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  return null;
+}
+
+export function validateOAuthLoginInput(input: StartOAuthLoginInput) {
+  if (!input.origin) return failure("Missing OAuth origin", { origin: "Required" });
+  return null;
+}

--- a/apps/react-router-web/app/routes/forgot-password.tsx
+++ b/apps/react-router-web/app/routes/forgot-password.tsx
@@ -16,31 +16,31 @@ import {
   useFetcher,
   useSearchParams,
 } from "react-router";
-import { createClient } from "~/lib/supabase/server";
+import { startPasswordReset as startPasswordResetWorkflow } from "~/auth/workflows/server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
   const formData = await request.formData();
-  const email = formData.get("email") as string;
-
-  const { supabase, headers } = createClient(request);
   const origin = new URL(request.url).origin;
-
-  // Send the actual reset password email
-  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+  const { result, headers } = await startPasswordResetWorkflow(request, {
+    email: String(formData.get("email") ?? ""),
     redirectTo: `${origin}/auth/confirm?next=/update-password`,
   });
 
-  if (error) {
+  if (!result.ok) {
     return data(
       {
-        error: error instanceof Error ? error.message : "An error occurred",
-        data: { email },
+        error: result.message,
+        data: { email: String(formData.get("email") ?? "") },
       },
       { headers },
     );
   }
 
-  return redirect("/forgot-password?success");
+  if (result.status !== "password-reset-requested") {
+    return data({ error: "Unexpected password reset result" }, { headers });
+  }
+
+  return redirect(result.redirectTo, { headers });
 };
 
 export default function ForgotPassword() {

--- a/apps/react-router-web/app/routes/login.tsx
+++ b/apps/react-router-web/app/routes/login.tsx
@@ -14,51 +14,42 @@ import {
   redirect,
   useFetcher,
 } from "react-router";
-import { createClient } from "~/lib/supabase/server";
+import {
+  login as loginWorkflow,
+  startOAuthLogin as startOAuthLoginWorkflow,
+} from "~/auth/workflows/server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { supabase, headers } = createClient(request);
   const formData = await request.formData();
   const submission = formData.get("submission") as string;
 
   if (submission === "github") {
-    const origin = new URL(request.url).origin;
-    const { data, error } = await supabase.auth.signInWithOAuth({
-      provider: "github",
-      options: {
-        redirectTo: `${origin}/auth/oauth?next=/protected`,
-      },
+    const { result, headers } = await startOAuthLoginWorkflow(request, {
+      origin: new URL(request.url).origin,
     });
 
-    if (data.url) {
-      return redirect(data.url);
+    if (!result.ok) {
+      return { error: result.message };
+    }
+    if (result.status !== "oauth-redirect") {
+      return { error: "Unexpected OAuth result" };
     }
 
-    if (error) {
-      return {
-        error: error instanceof Error ? error.message : "An error occurred",
-      };
-    }
-    return {};
+    return redirect(result.externalUrl, { headers });
   }
 
   if (submission === "credentials") {
-    const email = formData.get("email") as string;
-    const password = formData.get("password") as string;
-
-    const { error } = await supabase.auth.signInWithPassword({
-      email,
-      password,
+    const { result, headers } = await loginWorkflow(request, {
+      email: String(formData.get("email") ?? ""),
+      password: String(formData.get("password") ?? ""),
     });
 
-    if (error) {
-      return {
-        error: error instanceof Error ? error.message : "An error occurred",
-      };
+    if (!result.ok) return { error: result.message };
+    if (result.status !== "signed-in") {
+      return { error: "Unexpected login result" };
     }
 
-    // Update this route to redirect to an authenticated route. The user already has an active session.
-    return redirect("/protected", { headers });
+    return redirect(result.redirectTo, { headers });
   }
 
   return { error: "Invalid submission" };
@@ -73,7 +64,7 @@ export default function Login() {
 
   const credentialsLoading = credentialsFetcher.state === "submitting";
   const oauthLoading = oauthFetcher.state === "submitting";
-  const loading = credentialsLoading ?? oauthLoading;
+  const loading = credentialsLoading || oauthLoading;
 
   return (
     <div className="flex min-h-svh w-full items-center justify-center p-6 md:p-10">

--- a/apps/react-router-web/app/routes/logout.tsx
+++ b/apps/react-router-web/app/routes/logout.tsx
@@ -1,16 +1,13 @@
 import { type ActionFunctionArgs, redirect } from "react-router";
-import { createClient } from "~/lib/supabase/server";
+import { logout as logoutWorkflow } from "~/auth/workflows/server";
 
 export async function loader({ request }: ActionFunctionArgs) {
-  const { supabase, headers } = createClient(request);
+  const { result, headers } = await logoutWorkflow(request);
 
-  const { error } = await supabase.auth.signOut();
-
-  if (error) {
-    console.error(error);
-    return { success: false, error: error.message };
+  if (!result.ok) return { success: false, error: result.message };
+  if (result.status !== "signed-out") {
+    return { success: false, error: "Unexpected logout result" };
   }
 
-  // Redirect to dashboard or home page after successful sign-in
-  return redirect("/", { headers });
+  return redirect(result.redirectTo, { headers });
 }

--- a/apps/react-router-web/app/routes/sign-up.tsx
+++ b/apps/react-router-web/app/routes/sign-up.tsx
@@ -15,43 +15,23 @@ import {
   useFetcher,
   useSearchParams,
 } from "react-router";
-import { createClient } from "~/lib/supabase/server";
+import { signUp as signUpWorkflow } from "~/auth/workflows/server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { supabase } = createClient(request);
-
   const url = new URL(request.url);
   const origin = url.origin;
-
   const formData = await request.formData();
-
-  const email = formData.get("email") as string;
-  const password = formData.get("password") as string;
-  const repeatPassword = formData.get("repeat-password") as string;
-
-  if (!password) {
-    return {
-      error: "Password is required",
-    };
-  }
-
-  if (password !== repeatPassword) {
-    return { error: "Passwords do not match" };
-  }
-
-  const { error } = await supabase.auth.signUp({
-    email,
-    password,
-    options: {
-      emailRedirectTo: `${origin}/protected`,
-    },
+  const { result, headers } = await signUpWorkflow(request, {
+    email: String(formData.get("email") ?? ""),
+    password: String(formData.get("password") ?? ""),
+    repeatPassword: String(formData.get("repeat-password") ?? ""),
+    emailRedirectTo: `${origin}/protected`,
   });
 
-  if (error) {
-    return { error: error.message };
-  }
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "signed-up") return { error: "Unexpected sign-up result" };
 
-  return redirect("/sign-up?success");
+  return redirect(result.redirectTo, { headers });
 };
 
 export default function SignUp() {

--- a/apps/react-router-web/app/routes/test.tsx
+++ b/apps/react-router-web/app/routes/test.tsx
@@ -59,7 +59,16 @@ export default function Test({ loaderData }: Route.ComponentProps) {
 
   return (
     <>
-      <Navbar />
+      <Navbar
+        actions={[
+          {
+            text: "Logout",
+            href: "/logout",
+            isButton: true,
+            variant: "outline",
+          },
+        ]}
+      />
       <main className="container mx-auto min-h-screen w-full overflow-hidden">
         <div className="flex w-full gap-6">
           <Dialog>
@@ -68,6 +77,7 @@ export default function Test({ loaderData }: Route.ComponentProps) {
                 size="icon-sm"
                 variant="ghost"
                 className="hover:cursor-pointer"
+                aria-label="Open profile dialog"
               >
                 <Avatar>
                   <AvatarImage
@@ -125,7 +135,7 @@ export default function Test({ loaderData }: Route.ComponentProps) {
                         <img
                           className="object-cover"
                           src={profile?.avatar_url ?? profileImage}
-                          alt={initials ?? "?"}
+                          alt="Profile avatar"
                         />
                       </ItemMedia>
                     </ItemHeader>

--- a/apps/react-router-web/app/routes/update-password.tsx
+++ b/apps/react-router-web/app/routes/update-password.tsx
@@ -9,27 +9,20 @@ import {
 import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
 import { type ActionFunctionArgs, redirect, useFetcher } from "react-router";
-import { createClient } from "~/lib/supabase/server";
+import { updatePassword as updatePasswordWorkflow } from "~/auth/workflows/server";
 
 export const action = async ({ request }: ActionFunctionArgs) => {
-  const { supabase, headers } = createClient(request);
   const formData = await request.formData();
-  const password = formData.get("password") as string;
+  const { result, headers } = await updatePasswordWorkflow(request, {
+    password: String(formData.get("password") ?? ""),
+  });
 
-  if (!password) {
-    return { error: "Password is required" };
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "password-updated") {
+    return { error: "Unexpected password update result" };
   }
 
-  const { error } = await supabase.auth.updateUser({ password: password });
-
-  if (error) {
-    return {
-      error: error instanceof Error ? error.message : "An error occurred",
-    };
-  }
-
-  // Redirect to sign-in page after successful password update
-  return redirect("/protected", { headers });
+  return redirect(result.redirectTo, { headers });
 };
 
 export default function Page() {

--- a/apps/react-router-web/e2e-server.js
+++ b/apps/react-router-web/e2e-server.js
@@ -1,0 +1,43 @@
+import "dotenv/config";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { getLocalSupabaseEnv } from "../../scripts/lib/supabase-local-env.mjs";
+
+const { SUPABASE_URL, SUPABASE_ANON_KEY } = getLocalSupabaseEnv({
+  cwd: fileURLToPath(new URL("../..", import.meta.url)),
+});
+
+const port = process.env.PORT ?? "4173";
+const baseUrl =
+  process.env.PLAYWRIGHT_TEST_BASE_URL ?? `http://127.0.0.1:${port}`;
+
+const child = spawn(
+  "pnpm",
+  ["exec", "react-router", "dev", "--host", "127.0.0.1", "--port", port],
+  {
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    env: {
+      ...process.env,
+      NODE_ENV: "development",
+      PORT: port,
+      PLAYWRIGHT_TEST_BASE_URL: baseUrl,
+      SUPABASE_URL,
+      SUPABASE_ANON_KEY,
+      VITE_SUPABASE_URL: SUPABASE_URL,
+      VITE_SUPABASE_ANON_KEY: SUPABASE_ANON_KEY,
+    },
+  },
+);
+
+child.on("exit", (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exit(code ?? 0);
+});
+
+process.on("SIGINT", () => child.kill("SIGINT"));
+process.on("SIGTERM", () => child.kill("SIGTERM"));

--- a/apps/react-router-web/package.json
+++ b/apps/react-router-web/package.json
@@ -5,6 +5,11 @@
   "type": "module",
   "scripts": {
     "test": "vitest run",
+    "e2e:bootstrap": "node ../../scripts/bootstrap-playwright-supabase-user.mjs",
+    "e2e:server": "node ./e2e-server.js",
+    "test:e2e": "pnpm e2e:bootstrap && playwright test",
+    "test:e2e:smoke": "pnpm e2e:bootstrap && playwright test --project=smoke",
+    "test:e2e:integration": "pnpm e2e:bootstrap && playwright test --project=integration",
     "build": "react-router build",
     "dev": "react-router dev",
     "dev:test": "node ./server/dev-server.js",
@@ -52,6 +57,7 @@
   },
   "devDependencies": {
     "@react-router/dev": "7.18.1",
+    "@playwright/test": "^1.55.0",
     "@repo/eslint-config": "workspace:*",
     "@repo/types": "workspace:*",
     "@repo/typescript-config": "workspace:*",

--- a/apps/react-router-web/playwright.config.ts
+++ b/apps/react-router-web/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? "4173");
+const baseURL =
+  process.env.PLAYWRIGHT_TEST_BASE_URL ?? `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./playwright/tests",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL,
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "pnpm e2e:server",
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    cwd: process.cwd(),
+  },
+  projects: [
+    {
+      name: "smoke",
+      testMatch: /smoke\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+    {
+      name: "integration",
+      testMatch: /integration\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+    },
+  ],
+});

--- a/apps/react-router-web/playwright/fixtures/test-user.ts
+++ b/apps/react-router-web/playwright/fixtures/test-user.ts
@@ -1,0 +1,10 @@
+export const testUser = {
+  email: process.env.PLAYWRIGHT_TEST_EMAIL ?? "playwright@example.com",
+  password:
+    process.env.PLAYWRIGHT_TEST_PASSWORD ?? "playwright-password-123",
+  username: process.env.PLAYWRIGHT_TEST_USERNAME ?? "playwright-user",
+  fullName: process.env.PLAYWRIGHT_TEST_FULL_NAME ?? "Playwright User",
+  avatarUrl:
+    process.env.PLAYWRIGHT_TEST_AVATAR_URL ??
+    "https://example.com/playwright-avatar.png",
+};

--- a/apps/react-router-web/playwright/pages/login-page.ts
+++ b/apps/react-router-web/playwright/pages/login-page.ts
@@ -1,0 +1,16 @@
+import { expect, type Page } from "@playwright/test";
+
+export class LoginPage {
+  constructor(private readonly page: Page) {}
+
+  async goto() {
+    await this.page.goto("/login");
+    await expect(this.page.getByRole("heading", { name: "Login" })).toBeVisible();
+  }
+
+  async login(input: { email: string; password: string }) {
+    await this.page.getByLabel("Email").fill(input.email);
+    await this.page.getByLabel("Password").fill(input.password);
+    await this.page.getByRole("button", { name: "Login" }).click();
+  }
+}

--- a/apps/react-router-web/playwright/pages/test-page.ts
+++ b/apps/react-router-web/playwright/pages/test-page.ts
@@ -1,0 +1,51 @@
+import { expect, type Page } from "@playwright/test";
+
+export class TestPage {
+  constructor(private readonly page: Page) {}
+
+  async expectLoaded() {
+    await expect(
+      this.page.getByRole("button", { name: "Open profile dialog" }),
+    ).toBeVisible();
+    await expect(
+      this.page.getByRole("button", { name: "Give me a toast" }),
+    ).toBeVisible();
+  }
+
+  async openProfileDialog() {
+    await this.page.getByRole("button", { name: "Open profile dialog" }).click();
+    await expect(
+      this.page.getByRole("heading", { name: "My Profile Info" }),
+    ).toBeVisible();
+  }
+
+  async expectProfile(input: {
+    email: string;
+    username: string;
+    verifiedText: string;
+    avatarUrl: string;
+  }) {
+    await expect(this.page.getByText(input.email)).toBeVisible();
+    await expect(this.page.getByText(input.username)).toBeVisible();
+    await expect(this.page.getByText(input.verifiedText)).toBeVisible();
+    await expect(this.page.getByAltText("Profile avatar")).toHaveAttribute(
+      "src",
+      input.avatarUrl,
+    );
+  }
+
+  async closeProfileDialog() {
+    await this.page.getByRole("button", { name: "Close" }).click();
+    await expect(
+      this.page.getByRole("heading", { name: "My Profile Info" }),
+    ).not.toBeVisible();
+  }
+
+  async triggerToast() {
+    await this.page.getByRole("button", { name: "Give me a toast" }).click();
+  }
+
+  async logout() {
+    await this.page.getByRole("link", { name: "Logout" }).click();
+  }
+}

--- a/apps/react-router-web/playwright/tests/integration.spec.ts
+++ b/apps/react-router-web/playwright/tests/integration.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+import { testUser } from "../fixtures/test-user";
+import { LoginPage } from "../pages/login-page";
+import { TestPage } from "../pages/test-page";
+
+test("shows a toast after login on the authenticated example route", async ({
+  page,
+}) => {
+  const loginPage = new LoginPage(page);
+  const testPage = new TestPage(page);
+
+  await loginPage.goto();
+  await loginPage.login({
+    email: testUser.email,
+    password: testUser.password,
+  });
+
+  await page.waitForURL("**/test");
+  await testPage.expectLoaded();
+  await testPage.triggerToast();
+
+  await expect(page.getByText("My first toast")).toBeVisible();
+});

--- a/apps/react-router-web/playwright/tests/smoke.spec.ts
+++ b/apps/react-router-web/playwright/tests/smoke.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+import { testUser } from "../fixtures/test-user";
+import { LoginPage } from "../pages/login-page";
+import { TestPage } from "../pages/test-page";
+
+test("login, inspect profile, logout, and block protected revisit", async ({
+  page,
+}) => {
+  const loginPage = new LoginPage(page);
+  const testPage = new TestPage(page);
+
+  await loginPage.goto();
+  await loginPage.login({
+    email: testUser.email,
+    password: testUser.password,
+  });
+
+  await page.waitForURL("**/test");
+  await testPage.expectLoaded();
+  await testPage.openProfileDialog();
+  await testPage.expectProfile({
+    email: testUser.email,
+    username: testUser.username,
+    verifiedText: "yes",
+    avatarUrl: testUser.avatarUrl,
+  });
+  await testPage.closeProfileDialog();
+
+  await testPage.logout();
+  await page.waitForURL("**/");
+
+  await page.goto("/test");
+  await page.waitForURL("**/login");
+  await expect(page.getByRole("heading", { name: "Login" })).toBeVisible();
+});

--- a/apps/web/CONTEXT.md
+++ b/apps/web/CONTEXT.md
@@ -52,7 +52,12 @@ Auth operations use Next.js server actions in `app/auth/actions.ts`:
 - `oauthLogin(origin)` — initiates GitHub OAuth flow
 - `logout()` — signs out, redirects to login
 
-All auth actions use `redirect()` for navigation and `revalidatePath("/", "layout")` to refresh the layout.
+The server actions are thin framework adapters around the auth workflow module in `app/auth/workflows/`:
+- `server.ts` — creates the Supabase adapter for server actions
+- `operations.ts` — owns validation, auth orchestration, and result shaping
+- `types.ts` / `validation.ts` — define the auth workflow interface and invariants
+
+The auth workflow module returns typed results; `app/auth/actions.ts` maps those results to `redirect()` and `revalidatePath("/", "layout")`.
 
 ### TanStack Query
 
@@ -97,3 +102,5 @@ Themes are styled via CSS variables in `@repo/ui/src/styles/themes/`.
 | **Protected route** | Any route under `/protected/` that requires authentication |
 | **Theme** | A visual style defined by CSS variables (e.g., "supabase", "vercel", "neobrutalism") |
 | **Server action** | A Next.js server-side function called from client components for mutations |
+| **Auth workflow** | The local module in `app/auth/workflows/` that owns auth validation, Supabase orchestration, and typed auth results |
+| **Framework adapter** | A Next.js server action or form that translates framework input/output around the auth workflow |

--- a/apps/web/app/auth/actions.ts
+++ b/apps/web/app/auth/actions.ts
@@ -1,49 +1,118 @@
 "use server";
 
-import { createClient } from "@/lib/supabase/server";
+import {
+  login as loginWorkflow,
+  logout as logoutWorkflow,
+  signUp as signUpWorkflow,
+  startOAuthLogin as startOAuthLoginWorkflow,
+  startPasswordReset as startPasswordResetWorkflow,
+  updatePassword as updatePasswordWorkflow,
+} from "@/app/auth/workflows/server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-export async function signup(formData: FormData) {
-  const supabase = await createClient();
+export type AuthActionState = {
+  error?: string;
+  success?: string;
+};
 
-  const { error } = await supabase.auth.signUp({
-    email: formData.get("email") as string,
-    password: formData.get("password") as string,
+export const initialAuthActionState: AuthActionState = {};
+
+export async function signup(
+  _: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
+  const origin = String(formData.get("origin") ?? "");
+
+  const result = await signUpWorkflow({
+    email: String(formData.get("email") ?? ""),
+    password: String(formData.get("password") ?? ""),
+    repeatPassword: String(formData.get("repeat-password") ?? ""),
+    emailRedirectTo: `${origin}/protected`,
   });
-  if (error) redirect("/error");
 
-  revalidatePath("/", "layout");
-  redirect("/protected");
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "signed-up") return { error: "Unexpected sign-up result" };
+
+  redirect(result.redirectTo);
 }
 
-export async function login(formData: FormData) {
-  const supabase = await createClient();
-
-  const { error } = await supabase.auth.signInWithPassword({
-    email: formData.get("email") as string,
-    password: formData.get("password") as string,
+export async function login(
+  _: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
+  const result = await loginWorkflow({
+    email: String(formData.get("email") ?? ""),
+    password: String(formData.get("password") ?? ""),
   });
-  if (error) redirect("/auth/error");
 
-  revalidatePath("/", "layout");
-  redirect("/protected");
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "signed-in") return { error: "Unexpected login result" };
+
+  if (result.revalidateLayout) {
+    revalidatePath("/", "layout");
+  }
+
+  redirect(result.redirectTo);
 }
 
 export async function oauthLogin(origin: string) {
-  const supabase = await createClient();
+  const result = await startOAuthLoginWorkflow({ origin });
 
-  const { data, error } = await supabase.auth.signInWithOAuth({
-    provider: "github",
-    options: { redirectTo: `${origin}/auth/oauth` },
-  });
+  if (!result.ok) {
+    redirect(`/auth/error?error=${encodeURIComponent(result.message)}`);
+  }
+  if (result.status !== "oauth-redirect") {
+    redirect("/auth/error?error=Unexpected%20OAuth%20result");
+  }
 
-  if (error) redirect("/auth/error");
-  if (data.url) redirect(data.url);
+  redirect(result.externalUrl);
 }
 
 export async function logout() {
-  const supabase = await createClient();
-  await supabase.auth.signOut();
-  redirect("/auth/login");
+  const result = await logoutWorkflow();
+
+  if (!result.ok) {
+    redirect(`/auth/error?error=${encodeURIComponent(result.message)}`);
+  }
+  if (result.status !== "signed-out") {
+    redirect("/auth/error?error=Unexpected%20logout%20result");
+  }
+
+  redirect(result.redirectTo);
+}
+
+export async function requestPasswordReset(
+  _: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
+  const origin = String(formData.get("origin") ?? "");
+
+  const result = await startPasswordResetWorkflow({
+    email: String(formData.get("email") ?? ""),
+    redirectTo: `${origin}/auth/update-password`,
+  });
+
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "password-reset-requested") {
+    return { error: "Unexpected password reset result" };
+  }
+
+  return { success: result.message };
+}
+
+export async function saveUpdatedPassword(
+  _: AuthActionState,
+  formData: FormData,
+): Promise<AuthActionState> {
+  const result = await updatePasswordWorkflow({
+    password: String(formData.get("password") ?? ""),
+  });
+
+  if (!result.ok) return { error: result.message };
+  if (result.status !== "password-updated") {
+    return { error: "Unexpected password update result" };
+  }
+
+  redirect(result.redirectTo);
 }

--- a/apps/web/app/auth/workflows/operations.test.ts
+++ b/apps/web/app/auth/workflows/operations.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  login,
+  logout,
+  signUp,
+  startOAuthLogin,
+  startPasswordReset,
+  updatePassword,
+} from "./operations";
+import type { AuthAdapter } from "./types";
+
+const config = {
+  protectedRedirect: "/protected",
+  signUpRedirect: "/auth/sign-up-success",
+  loginRedirect: "/protected",
+  logoutRedirect: "/auth/login",
+};
+
+function createAuthAdapter(overrides: Partial<AuthAdapter> = {}): AuthAdapter {
+  return {
+    signInWithPassword: vi.fn(async () => ({ error: null })),
+    signUp: vi.fn(async () => ({ error: null })),
+    resetPasswordForEmail: vi.fn(async () => ({ error: null })),
+    updatePassword: vi.fn(async () => ({ error: null })),
+    signOut: vi.fn(async () => ({ error: null })),
+    signInWithOAuth: vi.fn(async () => ({
+      error: null,
+      url: "https://example.com/oauth",
+    })),
+    ...overrides,
+  };
+}
+
+describe("web auth workflow operations", () => {
+  it("rejects missing login credentials before the adapter", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await login({ email: "", password: "" }, auth, config);
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Email is required",
+      fieldErrors: { email: "Required" },
+    });
+    expect(auth.signInWithPassword).not.toHaveBeenCalled();
+  });
+
+  it("returns a protected redirect after successful login", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await login(
+      { email: "m@example.com", password: "secret" },
+      auth,
+      config,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "signed-in",
+      redirectTo: "/protected",
+      revalidateLayout: true,
+    });
+  });
+
+  it("keeps sign-up validation inside the workflow", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await signUp(
+      {
+        email: "m@example.com",
+        password: "secret",
+        repeatPassword: "different",
+        emailRedirectTo: "http://localhost:3000/protected",
+      },
+      auth,
+      config,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      message: "Passwords do not match",
+      fieldErrors: {
+        repeatPassword: "Must match password",
+      },
+    });
+    expect(auth.signUp).not.toHaveBeenCalled();
+  });
+
+  it("returns a success message for password reset", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await startPasswordReset(
+      {
+        email: "m@example.com",
+        redirectTo: "http://localhost:3000/auth/update-password",
+      },
+      auth,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "password-reset-requested",
+      message: "Password reset instructions sent",
+    });
+  });
+
+  it("returns a protected redirect after password update", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await updatePassword({ password: "new-secret" }, auth, config);
+
+    expect(result).toEqual({
+      ok: true,
+      status: "password-updated",
+      redirectTo: "/protected",
+    });
+  });
+
+  it("returns an external URL for oauth login", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await startOAuthLogin(
+      { origin: "http://localhost:3000" },
+      auth,
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      status: "oauth-redirect",
+      externalUrl: "https://example.com/oauth",
+    });
+  });
+
+  it("returns the logout redirect from the workflow", async () => {
+    const auth = createAuthAdapter();
+
+    const result = await logout(auth, config);
+
+    expect(result).toEqual({
+      ok: true,
+      status: "signed-out",
+      redirectTo: "/auth/login",
+    });
+  });
+});

--- a/apps/web/app/auth/workflows/operations.ts
+++ b/apps/web/app/auth/workflows/operations.ts
@@ -1,0 +1,127 @@
+import type {
+  AuthAdapter,
+  AuthWorkflowResult,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+import {
+  validateLoginInput,
+  validateOAuthLoginInput,
+  validatePasswordResetInput,
+  validateSignUpInput,
+  validateUpdatePasswordInput,
+} from "./validation";
+
+type AuthWorkflowConfig = {
+  protectedRedirect: string;
+  signUpRedirect: string;
+  loginRedirect: string;
+  logoutRedirect: string;
+};
+
+export async function login(
+  input: LoginInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateLoginInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.signInWithPassword(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-in",
+    redirectTo: config.loginRedirect,
+    revalidateLayout: true,
+  };
+}
+
+export async function signUp(
+  input: SignUpInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateSignUpInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.signUp(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-up",
+    redirectTo: config.signUpRedirect,
+  };
+}
+
+export async function startPasswordReset(
+  input: StartPasswordResetInput,
+  auth: AuthAdapter,
+): Promise<AuthWorkflowResult> {
+  const invalid = validatePasswordResetInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.resetPasswordForEmail(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "password-reset-requested",
+    message: "Password reset instructions sent",
+  };
+}
+
+export async function updatePassword(
+  input: UpdatePasswordInput,
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateUpdatePasswordInput(input);
+  if (invalid) return invalid;
+
+  const { error } = await auth.updatePassword(input);
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "password-updated",
+    redirectTo: config.protectedRedirect,
+  };
+}
+
+export async function logout(
+  auth: AuthAdapter,
+  config: AuthWorkflowConfig,
+): Promise<AuthWorkflowResult> {
+  const { error } = await auth.signOut();
+  if (error) return { ok: false, message: error };
+
+  return {
+    ok: true,
+    status: "signed-out",
+    redirectTo: config.logoutRedirect,
+  };
+}
+
+export async function startOAuthLogin(
+  input: StartOAuthLoginInput,
+  auth: AuthAdapter,
+): Promise<AuthWorkflowResult> {
+  const invalid = validateOAuthLoginInput(input);
+  if (invalid) return invalid;
+
+  const { error, url } = await auth.signInWithOAuth(input);
+  if (error) return { ok: false, message: error };
+  if (!url) return { ok: false, message: "Missing OAuth redirect URL" };
+
+  return {
+    ok: true,
+    status: "oauth-redirect",
+    externalUrl: url,
+  };
+}

--- a/apps/web/app/auth/workflows/server.ts
+++ b/apps/web/app/auth/workflows/server.ts
@@ -1,0 +1,94 @@
+import { createClient } from "@/lib/supabase/server";
+import type {
+  AuthAdapter,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+import {
+  login as loginOperation,
+  logout as logoutOperation,
+  signUp as signUpOperation,
+  startOAuthLogin as startOAuthLoginOperation,
+  startPasswordReset as startPasswordResetOperation,
+  updatePassword as updatePasswordOperation,
+} from "./operations";
+
+const config = {
+  protectedRedirect: "/protected",
+  signUpRedirect: "/auth/sign-up-success",
+  loginRedirect: "/protected",
+  logoutRedirect: "/auth/login",
+};
+
+async function createAuthAdapter(): Promise<AuthAdapter> {
+  const supabase = await createClient();
+
+  return {
+    async signInWithPassword(input) {
+      const { error } = await supabase.auth.signInWithPassword(input);
+      return { error: error?.message ?? null };
+    },
+    async signUp(input) {
+      const { error } = await supabase.auth.signUp({
+        email: input.email,
+        password: input.password,
+        options: {
+          emailRedirectTo: input.emailRedirectTo,
+        },
+      });
+      return { error: error?.message ?? null };
+    },
+    async resetPasswordForEmail(input) {
+      const { error } = await supabase.auth.resetPasswordForEmail(input.email, {
+        redirectTo: input.redirectTo,
+      });
+      return { error: error?.message ?? null };
+    },
+    async updatePassword(input) {
+      const { error } = await supabase.auth.updateUser({
+        password: input.password,
+      });
+      return { error: error?.message ?? null };
+    },
+    async signOut() {
+      const { error } = await supabase.auth.signOut();
+      return { error: error?.message ?? null };
+    },
+    async signInWithOAuth(input) {
+      const { data, error } = await supabase.auth.signInWithOAuth({
+        provider: "github",
+        options: {
+          redirectTo: `${input.origin}/auth/oauth`,
+        },
+      });
+      return { error: error?.message ?? null, url: data.url ?? null };
+    },
+  };
+}
+
+export async function login(input: LoginInput) {
+  return loginOperation(input, await createAuthAdapter(), config);
+}
+
+export async function signUp(input: SignUpInput) {
+  return signUpOperation(input, await createAuthAdapter(), config);
+}
+
+export async function startPasswordReset(input: StartPasswordResetInput) {
+  return startPasswordResetOperation(input, await createAuthAdapter());
+}
+
+export async function updatePassword(input: UpdatePasswordInput) {
+  return updatePasswordOperation(input, await createAuthAdapter(), config);
+}
+
+export async function logout() {
+  return logoutOperation(await createAuthAdapter(), config);
+}
+
+export async function startOAuthLogin(input: StartOAuthLoginInput) {
+  return startOAuthLoginOperation(input, await createAuthAdapter());
+}

--- a/apps/web/app/auth/workflows/types.ts
+++ b/apps/web/app/auth/workflows/types.ts
@@ -1,0 +1,74 @@
+export type AuthFieldErrors = Partial<
+  Record<"email" | "password" | "repeatPassword" | "origin", string>
+>;
+
+export type AuthWorkflowFailure = {
+  ok: false;
+  message: string;
+  fieldErrors?: AuthFieldErrors;
+};
+
+export type AuthWorkflowSuccess =
+  | {
+      ok: true;
+      status: "signed-in" | "signed-up" | "password-updated" | "signed-out";
+      redirectTo: string;
+      revalidateLayout?: boolean;
+    }
+  | {
+      ok: true;
+      status: "password-reset-requested";
+      message: string;
+    }
+  | {
+      ok: true;
+      status: "oauth-redirect";
+      externalUrl: string;
+    };
+
+export type AuthWorkflowResult = AuthWorkflowFailure | AuthWorkflowSuccess;
+
+export type LoginInput = {
+  email: string;
+  password: string;
+};
+
+export type SignUpInput = {
+  email: string;
+  password: string;
+  repeatPassword: string;
+  emailRedirectTo: string;
+};
+
+export type StartPasswordResetInput = {
+  email: string;
+  redirectTo: string;
+};
+
+export type UpdatePasswordInput = {
+  password: string;
+};
+
+export type StartOAuthLoginInput = {
+  origin: string;
+};
+
+export type AuthAdapter = {
+  signInWithPassword(input: { email: string; password: string }): Promise<{
+    error: string | null;
+  }>;
+  signUp(input: {
+    email: string;
+    password: string;
+    emailRedirectTo: string;
+  }): Promise<{ error: string | null }>;
+  resetPasswordForEmail(input: {
+    email: string;
+    redirectTo: string;
+  }): Promise<{ error: string | null }>;
+  updatePassword(input: { password: string }): Promise<{ error: string | null }>;
+  signOut(): Promise<{ error: string | null }>;
+  signInWithOAuth(input: {
+    origin: string;
+  }): Promise<{ error: string | null; url: string | null }>;
+};

--- a/apps/web/app/auth/workflows/validation.ts
+++ b/apps/web/app/auth/workflows/validation.ts
@@ -1,0 +1,62 @@
+import type {
+  AuthWorkflowFailure,
+  LoginInput,
+  SignUpInput,
+  StartOAuthLoginInput,
+  StartPasswordResetInput,
+  UpdatePasswordInput,
+} from "./types";
+
+function failure(
+  message: string,
+  fieldErrors?: AuthWorkflowFailure["fieldErrors"],
+): AuthWorkflowFailure {
+  return { ok: false, message, fieldErrors };
+}
+
+export function validateLoginInput(input: LoginInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  return null;
+}
+
+export function validateSignUpInput(input: SignUpInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  if (!input.repeatPassword) {
+    return failure("Repeat password is required", {
+      repeatPassword: "Required",
+    });
+  }
+  if (input.password !== input.repeatPassword) {
+    return failure("Passwords do not match", {
+      repeatPassword: "Must match password",
+    });
+  }
+  if (!input.emailRedirectTo) {
+    return failure("Missing sign-up redirect target");
+  }
+  return null;
+}
+
+export function validatePasswordResetInput(input: StartPasswordResetInput) {
+  if (!input.email) return failure("Email is required", { email: "Required" });
+  if (!input.redirectTo) return failure("Missing password reset redirect target");
+  return null;
+}
+
+export function validateUpdatePasswordInput(input: UpdatePasswordInput) {
+  if (!input.password) {
+    return failure("Password is required", { password: "Required" });
+  }
+  return null;
+}
+
+export function validateOAuthLoginInput(input: StartOAuthLoginInput) {
+  if (!input.origin) return failure("Missing OAuth origin", { origin: "Required" });
+  return null;
+}

--- a/apps/web/components/forgot-password-form.tsx
+++ b/apps/web/components/forgot-password-form.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import {
+  initialAuthActionState,
+  requestPasswordReset,
+} from "@/app/auth/actions";
 import { cn } from "@repo/ui/lib/utils";
-import { createClient } from "@/lib/supabase/client";
-import { Button } from "@repo/ui/components/button";
 import {
   Card,
   CardContent,
@@ -13,41 +15,26 @@ import {
 import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
 import Link from "next/link";
-import { useState } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { SubmitButton } from "@repo/ui/components/submit-button";
 
 export function ForgotPasswordForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const [email, setEmail] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [success, setSuccess] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
+  const [origin, setOrigin] = useState("");
+  const [state, formAction] = useActionState(
+    requestPasswordReset,
+    initialAuthActionState,
+  );
 
-  const handleForgotPassword = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const supabase = createClient();
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      // The url which will be included in the email. This URL needs to be configured in your redirect URLs in the Supabase dashboard at https://supabase.com/dashboard/project/_/auth/url-configuration
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: `${window.location.origin}/auth/update-password`,
-      });
-      if (error) throw error;
-      setSuccess(true);
-    } catch (error: unknown) {
-      setError(error instanceof Error ? error.message : "An error occurred");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
-      {success ? (
+      {state.success ? (
         <Card>
           <CardHeader>
             <CardTitle className="text-2xl">Check Your Email</CardTitle>
@@ -70,25 +57,21 @@ export function ForgotPasswordForm({
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleForgotPassword}>
+            <form action={formAction}>
+              <input type="hidden" name="origin" value={origin} />
               <div className="flex flex-col gap-6">
                 <div className="grid gap-2">
                   <Label htmlFor="email">Email</Label>
                   <Input
                     id="email"
+                    name="email"
                     type="email"
                     placeholder="m@example.com"
                     required
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
                   />
                 </div>
-                {error && <p className="text-sm text-red-500">{error}</p>}
-                <SubmitButton
-                  pendingText="Sending"
-                  className="w-full"
-                  disabled={isLoading}
-                >
+                {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+                <SubmitButton pendingText="Sending" className="w-full">
                   Send reset email
                 </SubmitButton>
               </div>

--- a/apps/web/components/login-form.tsx
+++ b/apps/web/components/login-form.tsx
@@ -1,4 +1,6 @@
-import { login } from "@/app/auth/actions";
+"use client";
+
+import { initialAuthActionState, login } from "@/app/auth/actions";
 import {
   Card,
   CardContent,
@@ -11,11 +13,14 @@ import { Label } from "@repo/ui/components/label";
 import { SubmitButton } from "@repo/ui/components/submit-button";
 import { cn } from "@repo/ui/lib/utils";
 import Link from "next/link";
+import { useActionState } from "react";
 
 export function LoginForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
+  const [state, formAction] = useActionState(login, initialAuthActionState);
+
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
       <Card>
@@ -26,7 +31,7 @@ export function LoginForm({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form action={login}>
+          <form action={formAction}>
             <div className="flex flex-col gap-6">
               <div className="grid gap-2">
                 <Label htmlFor="email">Email</Label>
@@ -50,6 +55,7 @@ export function LoginForm({
                 </div>
                 <Input id="password" type="password" name="password" required />
               </div>
+              {state.error && <p className="text-sm text-red-500">{state.error}</p>}
               <SubmitButton className="w-full" pendingText="Logging In">
                 Login
               </SubmitButton>

--- a/apps/web/components/logout-button.tsx
+++ b/apps/web/components/logout-button.tsx
@@ -1,21 +1,13 @@
-import { createClient } from "@/lib/supabase/server";
+import { logout } from "@/app/auth/actions";
 import { Button } from "@repo/ui/components/button";
 import { SubmitButton } from "@repo/ui/components/submit-button";
 import { cn } from "@repo/ui/lib/utils";
-import { redirect } from "next/navigation";
 import React from "react";
 
 export function LogoutButton({
   className,
   ...props
 }: React.ComponentProps<typeof Button>) {
-  const logout = async () => {
-    "use server";
-    const supabase = await createClient();
-    await supabase.auth.signOut();
-    redirect("/auth/login");
-  };
-
   return (
     <form action={logout}>
       <SubmitButton className={cn("w-full", className)} {...props}>

--- a/apps/web/components/sign-up-form.tsx
+++ b/apps/web/components/sign-up-form.tsx
@@ -1,8 +1,7 @@
 "use client";
 
+import { initialAuthActionState, signup } from "@/app/auth/actions";
 import { cn } from "@repo/ui/lib/utils";
-import { createClient } from "@/lib/supabase/client";
-import { Button } from "@repo/ui/components/button";
 import {
   Card,
   CardContent,
@@ -13,49 +12,19 @@ import {
 import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { SubmitButton } from "@repo/ui/components/submit-button";
 
 export function SignUpForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [repeatPassword, setRepeatPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const router = useRouter();
+  const [origin, setOrigin] = useState("");
+  const [state, formAction] = useActionState(signup, initialAuthActionState);
 
-  const handleSignUp = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const supabase = createClient();
-    setIsLoading(true);
-    setError(null);
-
-    if (password !== repeatPassword) {
-      setError("Passwords do not match");
-      setIsLoading(false);
-      return;
-    }
-
-    try {
-      const { error } = await supabase.auth.signUp({
-        email,
-        password,
-        options: {
-          emailRedirectTo: `${window.location.origin}/protected`,
-        },
-      });
-      if (error) throw error;
-      router.push("/auth/sign-up-success");
-    } catch (error: unknown) {
-      setError(error instanceof Error ? error.message : "An error occurred");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  useEffect(() => {
+    setOrigin(window.location.origin);
+  }, []);
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -65,17 +34,17 @@ export function SignUpForm({
           <CardDescription>Create a new account</CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSignUp}>
+          <form action={formAction}>
+            <input type="hidden" name="origin" value={origin} />
             <div className="flex flex-col gap-6">
               <div className="grid gap-2">
                 <Label htmlFor="email">Email</Label>
                 <Input
                   id="email"
+                  name="email"
                   type="email"
                   placeholder="m@example.com"
                   required
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
                 />
               </div>
               <div className="grid gap-2">
@@ -84,10 +53,9 @@ export function SignUpForm({
                 </div>
                 <Input
                   id="password"
+                  name="password"
                   type="password"
                   required
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
                 />
               </div>
               <div className="grid gap-2">
@@ -96,18 +64,13 @@ export function SignUpForm({
                 </div>
                 <Input
                   id="repeat-password"
+                  name="repeat-password"
                   type="password"
                   required
-                  value={repeatPassword}
-                  onChange={(e) => setRepeatPassword(e.target.value)}
                 />
               </div>
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <SubmitButton
-                pendingText="Creating Account"
-                className="w-full"
-                disabled={isLoading}
-              >
+              {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+              <SubmitButton pendingText="Creating Account" className="w-full">
                 Sign up
               </SubmitButton>
             </div>

--- a/apps/web/components/update-password-form.tsx
+++ b/apps/web/components/update-password-form.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import {
+  initialAuthActionState,
+  saveUpdatedPassword,
+} from "@/app/auth/actions";
 import { cn } from "@repo/ui/lib/utils";
-import { createClient } from "@/lib/supabase/client";
-import { Button } from "@repo/ui/components/button";
 import {
   Card,
   CardContent,
@@ -12,36 +14,17 @@ import {
 } from "@repo/ui/components/card";
 import { Input } from "@repo/ui/components/input";
 import { Label } from "@repo/ui/components/label";
-import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useActionState } from "react";
 
 import { SubmitButton } from "@repo/ui/components/submit-button";
 export function UpdatePasswordForm({
   className,
   ...props
 }: React.ComponentPropsWithoutRef<"div">) {
-  const [password, setPassword] = useState("");
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const router = useRouter();
-
-  const handleForgotPassword = async (e: React.FormEvent) => {
-    e.preventDefault();
-    const supabase = createClient();
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const { error } = await supabase.auth.updateUser({ password });
-      if (error) throw error;
-      // Update this route to redirect to an authenticated route. The user already has an active session.
-      router.push("/protected");
-    } catch (error: unknown) {
-      setError(error instanceof Error ? error.message : "An error occurred");
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const [state, formAction] = useActionState(
+    saveUpdatedPassword,
+    initialAuthActionState,
+  );
 
   return (
     <div className={cn("flex flex-col gap-6", className)} {...props}>
@@ -53,25 +36,20 @@ export function UpdatePasswordForm({
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleForgotPassword}>
+          <form action={formAction}>
             <div className="flex flex-col gap-6">
               <div className="grid gap-2">
                 <Label htmlFor="password">New password</Label>
                 <Input
                   id="password"
+                  name="password"
                   type="password"
                   placeholder="New password"
                   required
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
                 />
               </div>
-              {error && <p className="text-sm text-red-500">{error}</p>}
-              <SubmitButton
-                pendingText="Saving"
-                className="w-full"
-                disabled={isLoading}
-              >
+              {state.error && <p className="text-sm text-red-500">{state.error}</p>}
+              <SubmitButton pendingText="Saving" className="w-full">
                 Save new password
               </SubmitButton>
             </div>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,10 @@
     "version-packages": "changeset version",
     "release": "turbo run build --affected && changeset publish",
     "update-types": "npx supabase gen types --lang=typescript --db-url \"$SUPABASE_DB_URL\" > packages/types/database.types.ts",
-    "knip": "knip"
+    "knip": "knip",
+    "test:react-router-web:e2e": "pnpm --filter react-router-web test:e2e",
+    "test:react-router-web:e2e:smoke": "pnpm --filter react-router-web test:e2e:smoke",
+    "test:react-router-web:e2e:integration": "pnpm --filter react-router-web test:e2e:integration"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.62.1
       '@react-router/dev':
         specifier: 7.18.1
         version: 7.18.1(@react-router/serve@7.18.1(react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@5.9.3))(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.18.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(tsx@4.19.3)(typescript@5.9.3)(vite@6.3.5(@types/node@20.17.19)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.3)(yaml@2.8.3))(yaml@2.8.3)
@@ -322,7 +325,7 @@ importers:
         version: 11.18.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
         specifier: ^16.2.11
-        version: 16.2.11(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        version: 16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -461,7 +464,7 @@ importers:
         version: 29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3))
       ts-jest:
         specifier: ^29.3.0
-        version: 29.3.0(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3)))(typescript@5.9.3)
 
   packages/logger:
     devDependencies:
@@ -2471,6 +2474,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -5783,6 +5791,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -7390,6 +7403,16 @@ packages:
 
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -9194,77 +9217,35 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-attributes@7.26.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-jsx@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -9281,88 +9262,40 @@ snapshots:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
 
-  '@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
-
   '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.26.10)':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/helper-plugin-utils': 7.26.5
-
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.26.5
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.25.9(@babel/core@7.26.10)':
     dependencies:
@@ -10844,6 +10777,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -13211,20 +13148,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  babel-jest@29.7.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/transform': 29.7.0
-      '@types/babel__core': 7.20.5
-      babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.29.0)
-      chalk: 4.1.2
-      graceful-fs: 4.2.11
-      slash: 3.0.0
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
   babel-plugin-istanbul@6.1.1:
     dependencies:
       '@babel/helper-plugin-utils': 7.26.5
@@ -13267,38 +13190,11 @@ snapshots:
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.26.10)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.26.10)
 
-  babel-preset-current-node-syntax@1.1.0(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.26.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.0)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.0)
-      '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
-    optional: true
-
   babel-preset-jest@29.6.3(@babel/core@7.26.10):
     dependencies:
       '@babel/core': 7.26.10
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.1.0(@babel/core@7.26.10)
-
-  babel-preset-jest@29.6.3(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.1.0(@babel/core@7.29.0)
-    optional: true
 
   balanced-match@1.0.2: {}
 
@@ -14616,6 +14512,9 @@ snapshots:
       universalify: 0.1.2
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -16145,7 +16044,7 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  next@16.2.11(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
@@ -16154,7 +16053,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.2.8)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.8)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.11
       '@next/swc-darwin-x64': 16.2.11
@@ -16165,6 +16064,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -16533,6 +16433,14 @@ snapshots:
       confbox: 0.2.4
       exsolve: 1.1.0
       pathe: 2.0.3
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 
@@ -17403,12 +17311,12 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  styled-jsx@5.1.6(@babel/core@7.26.10)(react@19.2.8):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.8):
     dependencies:
       client-only: 0.0.1
       react: 19.2.8
     optionalDependencies:
-      '@babel/core': 7.26.10
+      '@babel/core': 7.29.0
 
   stylis@4.2.0: {}
 
@@ -17564,7 +17472,7 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.3.0(@babel/core@7.29.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.29.0))(jest@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.3.0(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@20.17.19)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
@@ -17579,10 +17487,10 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.26.10
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
+      babel-jest: 29.7.0(@babel/core@7.26.10)
 
   ts-node@10.9.2(@types/node@20.17.19)(typescript@5.9.3):
     dependencies:

--- a/scripts/bootstrap-playwright-supabase-user.mjs
+++ b/scripts/bootstrap-playwright-supabase-user.mjs
@@ -1,0 +1,157 @@
+import { execFileSync } from "node:child_process";
+import { getLocalSupabaseEnv } from "./lib/supabase-local-env.mjs";
+
+const TEST_USER = {
+  email: process.env.PLAYWRIGHT_TEST_EMAIL ?? "playwright@example.com",
+  password:
+    process.env.PLAYWRIGHT_TEST_PASSWORD ?? "playwright-password-123",
+  username: process.env.PLAYWRIGHT_TEST_USERNAME ?? "playwright-user",
+  fullName: process.env.PLAYWRIGHT_TEST_FULL_NAME ?? "Playwright User",
+  avatarUrl:
+    process.env.PLAYWRIGHT_TEST_AVATAR_URL ??
+    "https://example.com/playwright-avatar.png",
+};
+
+async function listUsers(url, serviceRoleKey) {
+  const users = [];
+  let page = 1;
+  const perPage = 200;
+
+  while (true) {
+    const response = await fetch(
+      `${url}/auth/v1/admin/users?page=${page}&per_page=${perPage}`,
+      {
+        headers: {
+          apikey: serviceRoleKey,
+          Authorization: `Bearer ${serviceRoleKey}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      throw new Error(`Failed to list auth users: ${response.status}`);
+    }
+
+    const payload = await response.json();
+    const batch = payload.users ?? [];
+    users.push(...batch);
+
+    if (batch.length < perPage) break;
+    page += 1;
+  }
+
+  return users;
+}
+
+async function createUser(url, serviceRoleKey) {
+  const response = await fetch(`${url}/auth/v1/admin/users`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      email: TEST_USER.email,
+      password: TEST_USER.password,
+      email_confirm: true,
+      user_metadata: {
+        full_name: TEST_USER.fullName,
+        email_verified: true,
+        avatar_url: TEST_USER.avatarUrl,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to create auth user: ${response.status} ${body}`);
+  }
+
+  const payload = await response.json();
+  return payload.user ?? payload;
+}
+
+async function updateUser(url, serviceRoleKey, userId) {
+  const response = await fetch(`${url}/auth/v1/admin/users/${userId}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: serviceRoleKey,
+      Authorization: `Bearer ${serviceRoleKey}`,
+    },
+    body: JSON.stringify({
+      email: TEST_USER.email,
+      password: TEST_USER.password,
+      user_metadata: {
+        full_name: TEST_USER.fullName,
+        email_verified: true,
+        avatar_url: TEST_USER.avatarUrl,
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Failed to update auth user: ${response.status} ${body}`);
+  }
+
+  const payload = await response.json();
+  return payload.user ?? payload;
+}
+
+function escapeSqlLiteral(value) {
+  return value.replaceAll("'", "''");
+}
+
+function upsertProfile(dbUrl, userId) {
+  const sql = `
+    grant select, insert, update on table public.profiles to authenticated;
+
+    insert into public.profiles (id, username, avatar_url, website, updated_at)
+    values (
+      '${escapeSqlLiteral(userId)}',
+      '${escapeSqlLiteral(TEST_USER.username)}',
+      '${escapeSqlLiteral(TEST_USER.avatarUrl)}',
+      'https://example.com/playwright',
+      now()
+    )
+    on conflict (id)
+    do update set
+      username = excluded.username,
+      avatar_url = excluded.avatar_url,
+      website = excluded.website,
+      updated_at = excluded.updated_at;
+  `;
+
+  execFileSync("psql", [dbUrl, "-v", "ON_ERROR_STOP=1", "-c", sql], {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+  });
+}
+
+async function main() {
+  const { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, SUPABASE_DB_URL } =
+    getLocalSupabaseEnv();
+  const users = await listUsers(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  const existingUser = users.find((user) => user.email === TEST_USER.email);
+  const user = existingUser
+    ? await updateUser(
+        SUPABASE_URL,
+        SUPABASE_SERVICE_ROLE_KEY,
+        existingUser.id,
+      )
+    : await createUser(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+
+  upsertProfile(SUPABASE_DB_URL, user.id);
+
+  console.log(
+    `Playwright Supabase user is ready: ${TEST_USER.email} (${user.id})`,
+  );
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/scripts/lib/supabase-local-env.mjs
+++ b/scripts/lib/supabase-local-env.mjs
@@ -1,0 +1,65 @@
+import { execFileSync } from "node:child_process";
+
+function parseEnvOutput(output) {
+  return output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .reduce((env, line) => {
+      const separatorIndex = line.indexOf("=");
+      if (separatorIndex === -1) return env;
+
+      const key = line.slice(0, separatorIndex);
+      const rawValue = line.slice(separatorIndex + 1);
+      const value = rawValue.replace(/^["']|["']$/g, "");
+
+      env[key] = value;
+      return env;
+    }, {});
+}
+
+export function getLocalSupabaseEnv({ cwd = process.cwd() } = {}) {
+  const explicit = {
+    SUPABASE_URL: process.env.PLAYWRIGHT_SUPABASE_URL,
+    SUPABASE_ANON_KEY: process.env.PLAYWRIGHT_SUPABASE_ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: process.env.PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY,
+  };
+
+  if (
+    explicit.SUPABASE_URL &&
+    explicit.SUPABASE_ANON_KEY &&
+    explicit.SUPABASE_SERVICE_ROLE_KEY
+  ) {
+    return explicit;
+  }
+
+  let output;
+
+  try {
+    output = execFileSync("supabase", ["status", "-o", "env"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    throw new Error(
+      "Unable to read local Supabase credentials. Start Supabase with `supabase start`, or provide PLAYWRIGHT_SUPABASE_URL, PLAYWRIGHT_SUPABASE_ANON_KEY, and PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY.",
+      { cause: error },
+    );
+  }
+
+  const env = parseEnvOutput(output);
+
+  if (!env.API_URL || !env.ANON_KEY || !env.SERVICE_ROLE_KEY || !env.DB_URL) {
+    throw new Error(
+      "Local Supabase is running, but `supabase status -o env` did not return API_URL, ANON_KEY, SERVICE_ROLE_KEY, and DB_URL.",
+    );
+  }
+
+  return {
+    SUPABASE_URL: env.API_URL,
+    SUPABASE_ANON_KEY: env.ANON_KEY,
+    SUPABASE_SERVICE_ROLE_KEY: env.SERVICE_ROLE_KEY,
+    SUPABASE_DB_URL: env.DB_URL,
+  };
+}

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -12,6 +12,8 @@ create table profiles (
 
 alter table profiles enable row level security;
 
+grant select, insert, update on table profiles to authenticated;
+
 create policy "Public profiles are viewable by the owner."
   on profiles for select
   using ( auth.uid() = id );

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,19 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalEnv": [
+    "CI",
+    "PLAYWRIGHT_PORT",
+    "PLAYWRIGHT_TEST_BASE_URL",
+    "PLAYWRIGHT_TEST_EMAIL",
+    "PLAYWRIGHT_TEST_PASSWORD",
+    "PLAYWRIGHT_TEST_USERNAME",
+    "PLAYWRIGHT_TEST_FULL_NAME",
+    "PLAYWRIGHT_TEST_AVATAR_URL",
+    "PLAYWRIGHT_SUPABASE_URL",
+    "PLAYWRIGHT_SUPABASE_ANON_KEY",
+    "PLAYWRIGHT_SUPABASE_SERVICE_ROLE_KEY"
+  ],
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
## Summary

- Extract shared typed auth workflows for Next.js and React Router apps.
- Simplify framework routes and server actions around workflow adapters.
- Add unit and Playwright coverage for authentication flows.
- Configure local Supabase-backed Playwright execution.

## Testing

- `pnpm test`
- `pnpm --filter react-router-web test:e2e`
- Playwright smoke and integration workflows covering login, profile access, logout, and protected-route redirects.